### PR TITLE
Add CLI option to save generated playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ To run the PlaybookGen CLI tool:
 
 ```bash
 cd src/playbookgen
-python main.py [--output-yaml path/to/playbook.yml]
+python main.py [--output path/to/playbook.yml]
 ```
-Use the optional `--output-yaml` or `-o` argument to automatically save the
+Use the optional `--output` or `-o` argument to automatically save the
 generated YAML playbook to the provided file path.
 
 ### Troubleshooting

--- a/README.md
+++ b/README.md
@@ -43,8 +43,10 @@ To run the PlaybookGen CLI tool:
 
 ```bash
 cd src/playbookgen
-python main.py
+python main.py [--output-playbook path/to/playbook.yml]
 ```
+Use the optional `--output-playbook` argument to automatically save the
+generated YAML playbook to the provided file path.
 
 ### Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ To run the PlaybookGen CLI tool:
 
 ```bash
 cd src/playbookgen
-python main.py [--output-playbook path/to/playbook.yml]
+python main.py [--output-yaml path/to/playbook.yml]
 ```
-Use the optional `--output-playbook` argument to automatically save the
+Use the optional `--output-yaml` or `-o` argument to automatically save the
 generated YAML playbook to the provided file path.
 
 ### Troubleshooting

--- a/src/playbookgen/main.py
+++ b/src/playbookgen/main.py
@@ -8,8 +8,6 @@ from openai import OpenAI
 import json
 import yaml
 import argparse
-import os
-import re
 
 
 load_dotenv()
@@ -73,25 +71,10 @@ class PlaybookState:
 playbook_state = PlaybookState()
 
 
-def extract_yaml_from_messages(messages) -> Optional[str]:
-    """Return the last YAML code block found in assistant messages."""
-    pattern = re.compile(r"```yaml\n(.*?)```", re.DOTALL)
-    for msg in reversed(messages):
-        if msg.get("role") == "assistant" and msg.get("content"):
-            match = pattern.search(msg["content"])
-            if match:
-                return match.group(1).strip()
-    return None
-
-
-def write_playbook_to_file(yaml_text: str, path: str) -> None:
-    """Write provided YAML text to the given file path, creating directories."""
-    directory = os.path.dirname(path)
-    if directory:
-        os.makedirs(directory, exist_ok=True)
-    with open(path, "w") as f:
-        f.write(yaml_text)
-
+def save_playbook_to_file(yaml_content: str, file_path: str) -> None:
+    """Write the YAML playbook to the given file path."""
+    with open(file_path, "w") as f:
+        f.write(yaml_content)
 
 def add_playbook_step(
         step_type: str,
@@ -261,7 +244,16 @@ def run_full_turn(system_message, tools, messages):
     return messages[num_init_messages:]
 
 
-def main(output_file: Optional[str] = None):
+def main():
+    parser = argparse.ArgumentParser(description="Run the playbook generator")
+    parser.add_argument(
+        "--output-yaml",
+        "-o",
+        dest="output_yaml",
+        help="Path to write the final playbook YAML",
+    )
+    args = parser.parse_args()
+
     messages = []
     while True:
         try:
@@ -277,24 +269,9 @@ def main(output_file: Optional[str] = None):
             break
         finally:
             print("Current Attackmate Playbook:\n", playbook_state.to_yaml())
-
-    # After exiting the loop, optionally write the playbook to file
-    if output_file:
-        yaml_text = extract_yaml_from_messages(messages)
-        if yaml_text is None:
-            yaml_text = playbook_state.to_yaml()
-        write_playbook_to_file(yaml_text, output_file)
-        print(f"Playbook written to {output_file}")
+            save_playbook_to_file(playbook_state.to_yaml(), args.output_yaml)
+            print(f"Playbook written to {args.output_yaml}")
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="PlaybookGen interactive tool")
-    parser.add_argument(
-        "--output-playbook",
-        "-o",
-        type=str,
-        default=None,
-        help="Optional path to write the generated playbook YAML",
-    )
-    args = parser.parse_args()
-    main(output_file=args.output_playbook)
+    main()

--- a/src/playbookgen/utils/yaml_writer.py
+++ b/src/playbookgen/utils/yaml_writer.py
@@ -1,0 +1,20 @@
+import os
+import re
+from typing import Optional
+
+
+def extract_yaml_from_messages(message) -> Optional[str]:
+    """Return YAML code block in assistant message."""
+    pattern = re.compile(r"```yaml\n(.*?)```", re.DOTALL)
+    match = pattern.search(message)
+    if match:
+        return match.group(1).strip()
+    return None
+
+def write_playbook_to_file(yaml_text: str, path: str) -> None:
+    """Write provided YAML text to the given file path, creating directories."""
+    directory = os.path.dirname(path)
+    if directory:
+        os.makedirs(directory, exist_ok=True)
+    with open(path, "w") as f:
+        f.write(yaml_text)


### PR DESCRIPTION
## Summary
- save optional YAML output path in CLI
- add helper functions to extract assistant YAML and write to disk
- update README with new usage

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6859580f0860832d8ce6f95f1be5070a